### PR TITLE
Fix bug when `multilvl` method not used in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Metabarcoding - Pipeline
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10986177.svg)](https://doi.org/10.5281/zenodo.10986177)
+
 This is a Metabarcoding Pipeline developed for Illumina Sequencing Data at the
 Thuenen Institute of Biodiversity, Braunschweig by Wiebke Sickel & Lasse
 Krueger, with contributions from Brandon Seah.
-
 
 ## Prerequisites
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -284,8 +284,16 @@ rule taxonomy:
         stats_mqc="results/10_taxonomy/stats_mqc.{method}.{screening}.multilvl.{refdb}.csv",
     params:
         keep_results=True,
-        threshold_narrow=config["class_thresholds"]["multilvl"]["narrow"] if "multilvl" in config["class_thresholds"] else None,
-        threshold_broad=config["class_thresholds"]["multilvl"]["broad"] if "multilvl" in config["class_thresholds"] else None,
+        threshold_narrow=(
+            config["class_thresholds"]["multilvl"]["narrow"]
+            if "multilvl" in config["class_thresholds"]
+            else None
+        ),
+        threshold_broad=(
+            config["class_thresholds"]["multilvl"]["broad"]
+            if "multilvl" in config["class_thresholds"]
+            else None
+        ),
     threads: workflow.cores
     message:
         "Starting Multilevel Taxonomic Classification"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -284,8 +284,16 @@ rule taxonomy:
         stats_mqc="results/10_taxonomy/stats_mqc.{method}.{screening}.multilvl.{refdb}.csv",
     params:
         keep_results=True,
-        threshold_narrow=config["class_thresholds"]["multilvl"]["narrow"],
-        threshold_broad=config["class_thresholds"]["multilvl"]["broad"],
+        threshold_narrow=lambda: (
+            config["class_thresholds"]["multilvl"]["narrow"]
+            if "multilvl" in config["class_thresholds"]
+            else None
+        ),
+        threshold_broad=lambda: (
+            config["class_thresholds"]["multilvl"]["broad"]
+            if "multilvl" in config["class_thresholds"]
+            else None
+        ),,
     threads: workflow.cores
     message:
         "Starting Multilevel Taxonomic Classification"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -284,16 +284,8 @@ rule taxonomy:
         stats_mqc="results/10_taxonomy/stats_mqc.{method}.{screening}.multilvl.{refdb}.csv",
     params:
         keep_results=True,
-        threshold_narrow=lambda: (
-            config["class_thresholds"]["multilvl"]["narrow"]
-            if "multilvl" in config["class_thresholds"]
-            else None
-        ),
-        threshold_broad=lambda: (
-            config["class_thresholds"]["multilvl"]["broad"]
-            if "multilvl" in config["class_thresholds"]
-            else None
-        ),,
+        threshold_narrow=config["class_thresholds"]["multilvl"]["narrow"] if "multilvl" in config["class_thresholds"] else None,
+        threshold_broad=config["class_thresholds"]["multilvl"]["broad"] if "multilvl" in config["class_thresholds"] else None,
     threads: workflow.cores
     message:
         "Starting Multilevel Taxonomic Classification"


### PR DESCRIPTION
If user does not use the `multilvl` classification method, Snakemake still parses rule `taxonomy` which looks for config parameters for the `multilvl` method, and raises KeyError if config options were removed. This PR fixes the bug.