### PR TITLE
Update mafft to latest version on conda-forge

### DIFF
--- a/workflow/envs/mb_phylogeny.yaml
+++ b/workflow/envs/mb_phylogeny.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - mafft =7.520
+  - mafft =7.526
   - iqtree =2.2
   - fasttree =2.1
   - scikit-bio =0.5.9

--- a/workflow/envs/mb_pseudogenes.yaml
+++ b/workflow/envs/mb_pseudogenes.yaml
@@ -3,5 +3,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - mafft =7.520
+  - mafft =7.526
   - pytransaln =0.2.1


### PR DESCRIPTION
mafft recipe has been migrated from bioconda to conda-forge, per https://github.com/bioconda/bioconda-recipes/pull/47218

However, with strict channel dependency, this means that mamba/conda solver will refuse to install version 7.520 (only available from bioconda) because mafft is also available from a higher-priority channel, conda-forge. Specifying channel as a prefix, e.g. `bioconda::mafft` does not work either.

Recommendation for Snakemake is to use strict channel priority. However it is not possible to change channel priority for a single environment only, although this feature has been requested since 2019: https://github.com/conda/conda/issues/8675

The least disruptive change is therefore to update mafft dependency version to one of the versions available from conda-forge.